### PR TITLE
remove colons from book_name

### DIFF
--- a/main.py
+++ b/main.py
@@ -206,7 +206,7 @@ def main(argv):
         file_types = get_book_file_types(user, book['productId'])
         for file_type in file_types:
             if file_type in book_file_types:  # check if the file type entered is available by the current book
-                book_name = book['productName'].replace(' ', '_').replace('.', '_')
+                book_name = book['productName'].replace(' ', '_').replace('.', '_').replace(':', '_')
                 if separate:
                     filename = f'{root_directory}/{book_name}/{book_name}.{file_type}'
                     move_current_files(root_directory, book_name)


### PR DESCRIPTION
quick and dirty fix to handle the colon character (":") in book names (the colon is an invalid character for a windows filename)