### PR TITLE
No login; refresh existing JWT tokens

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,8 +9,8 @@
 # this is base url where i do the requests
 BASE_URL = "https://services.packtpub.com/"
 
-# URL to request jwt token, params by post are user and pass, return jwt token
-AUTH_ENDPOINT = "auth-v1/users/tokens"
+# URL to refresh jwt token
+REFRESH_ENDPOINT = "auth-v1/users/me/tokens"
 
 # URL to get all your books, two params that i change are offset and limit, method GET
 PRODUCTS_ENDPOINT = "entitlements-v1/users/me/products?sort=createdAt:DESC&offset={offset}&limit={limit}"

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ def get_url_book(user, book_id, format='pdf'):
 
     elif r.status_code == 401: # jwt expired 
         user.refresh_header() # refresh token 
-        get_url_book(user, book_id, format)  # call recursive 
+        return get_url_book(user, book_id, format)  # call recursive 
     
     print('ERROR (please copy and paste in the issue)')
     print(r.json())
@@ -85,7 +85,7 @@ def get_book_file_types(user, book_id):
     
     elif (r.status_code == 401): # jwt expired 
         user.refresh_header() # refresh token 
-        get_book_file_types(user, book_id, format)  # call recursive 
+        return get_book_file_types(user, book_id, format)  # call recursive 
     
     print('ERROR (please copy and paste in the issue)')
     print(r.json())
@@ -144,29 +144,29 @@ def does_dir_exist(directory):
 
 def main(argv):
     # thanks to https://github.com/ozzieperez/packtpub-library-downloader/blob/master/downloader.py
-    email = None
-    password = None
+    bearer_token = None
+    refresh_token = None
     root_directory = 'media' 
     book_file_types = ['pdf', 'mobi', 'epub', 'code']
     separate = None
     verbose = None
     quiet = None
-    errorMessage = 'Usage: main.py -e <email> -p <password> [-d <directory> -b <book file types> -s -v -q]'
+    errorMessage = 'Usage: main.py -t <bearer token> -r <refresh token> [-d <directory> -b <book file types> -s -v -q]'
 
     # get the command line arguments/options
     try:
         opts, args = getopt.getopt(
-            argv, 'e:p:d:b:svq', ['email=', 'pass=', 'directory=', 'books=', 'separate', 'verbose', 'quiet'])
+            argv, 't:r:d:b:svq', ['bearer_token=', 'refresh_token=', 'directory=', 'books=', 'separate', 'verbose', 'quiet'])
     except getopt.GetoptError:
         print(errorMessage)
         sys.exit(2)
 
     # hold the values of the command line options
     for opt, arg in opts:
-        if opt in ('-e', '--email'):
-            email = arg
-        elif opt in ('-p', '--pass'):
-            password = arg
+        if opt in ('-t', '--bearer'):
+            bearer_token = arg
+        elif opt in ('-r', '--refresh'):
+            refresh_token = arg
         elif opt in ('-d', '--directory'):
             root_directory = os.path.expanduser(
                 arg) if '~' in arg else os.path.abspath(arg)
@@ -184,7 +184,7 @@ def main(argv):
         sys.exit(2)
 
     # do we have the minimum required info?
-    if not email or not password:
+    if not bearer_token or not refresh_token:
         print(errorMessage)
         sys.exit(2)
 
@@ -192,7 +192,7 @@ def main(argv):
     does_dir_exist(root_directory)
 
     # create user with his properly header
-    user = User(email, password)
+    user = User(bearer_token, refresh_token)
 
     # get all your books
     books = get_books(user, is_verbose=verbose, is_quiet=quiet)

--- a/user.py
+++ b/user.py
@@ -21,7 +21,6 @@ class User:
     def __init__(self, bearer_token, refresh_token):
         self.bearer_token = bearer_token
         self.refresh_token = refresh_token
-        self.header["Authorization"] = bearer_token
         self.refresh_header()
 
     def refresh_jwt(self):


### PR DESCRIPTION
The script now refreshes existing JWT tokens, which are initially provided by the user.

To execute this, the user must:
1. Launch their favourite browser and navigate to the [PacktPub login page](https://account.packtpub.com/login)
3. Open the developer console and navigate to the network monitor tab
4. Enter their credentials into the page and login
5. Find the POST request to `https://services.packtpub.com/auth-v1/users/tokens` and extract the `refresh` and `access` (bearer) tokens. Refer screenshot below.
6. Launch as per usual with arguments `-t <access/bearer token> -r <refresh token>`

Ugly as hell but it works =) Ideally we'd capture the initial tokens directly from the browser session similar to the [Humble eBook Downloader](https://github.com/DMarby/humblebundle-ebook-downloader)

In the meantime though... _Looks like meat's back on the menu boys!_

![image](https://user-images.githubusercontent.com/19488147/71556903-433ec380-2a92-11ea-9ca7-b45cc775ab71.png)